### PR TITLE
Fix admin input error due to acf update

### DIFF
--- a/assets/js/input-5.js
+++ b/assets/js/input-5.js
@@ -1,8 +1,9 @@
-(function ($) {
-    // user
-    acf.fields.user = acf.fields.select.extend({
+(function($){
 
-        type: 'user_network'
+	var Field = acf.models.SelectField.extend({
+		type: 'user_network',	
+	});
+	
+	acf.registerFieldType( Field );
 
-    });
 })(jQuery);

--- a/assets/js/input-5.min.js
+++ b/assets/js/input-5.min.js
@@ -1,1 +1,1 @@
-!function(e){acf.fields.user=acf.fields.select.extend({type:"user_network"})}(jQuery);
+!function(e){var field=acf.models.SelectField.extend({type:"user_network"});acf.registerFieldType(field)}(jQuery);


### PR DESCRIPTION
This merge fixes an error in admin due to an ACF update:

`Uncaught TypeError: Cannot read property 'extend' of undefined`