### PR TITLE
fix(acf-base.php): nonces

### DIFF
--- a/fields/acf-base.php
+++ b/fields/acf-base.php
@@ -43,7 +43,9 @@
 	function ajax_query() {
 
 		// validate
-		if ( ! acf_verify_ajax() ) {
+		$nonce = acf_request_arg( 'nonce', '' );
+		$key   = acf_request_arg( 'field_key', '' );
+		if ( ! acf_verify_ajax( $nonce, $key ) ) {
 			die();
 		}
 


### PR DESCRIPTION
In a recent security update ACF changed nonce handling for ajax-fields (the old way no longer works): https://github.com/AdvancedCustomFields/acf/releases/tag/6.3.2